### PR TITLE
Fix preferences crash

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,6 +1,7 @@
 const Lang = imports.lang;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
+const GLib = imports.gi.GLib;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;


### PR DESCRIPTION
The GLib import is used on line 160, and the preferences window crashes without it.
I am running Gnome 3.26.2 on Arch Linux.